### PR TITLE
Hook comments into persistent datastore

### DIFF
--- a/portfolio/pom.xml
+++ b/portfolio/pom.xml
@@ -29,6 +29,12 @@
       <artifactId>gson</artifactId>
       <version>2.8.6</version>
     </dependency>
+
+    <dependency>
+      <groupId>com.google.appengine</groupId>
+      <artifactId>appengine-api-1.0-sdk</artifactId>
+      <version>1.9.59</version>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
Rework the system of submitting and pulling comments to take advantage of a persistent datastore. When comments are submitted, they are logged by their content and timestamp as a comment entity in the datastore. Then, the GET response builds and dispatches a query of all comments in the datastore. In coming updates, this query can be trivially changed to allow for limited and paginated pulling of comments.