### PR TITLE
Add user authentication and nickname backend with basic button frontend

### DIFF
--- a/portfolio/pom.xml
+++ b/portfolio/pom.xml
@@ -46,7 +46,7 @@
         <artifactId>appengine-maven-plugin</artifactId>
         <version>2.2.0</version>
         <configuration>
-          <deploy.projectId>henry-step-2020</deploy.projectId>
+          <deploy.projectId>henrysloan2-step-2020</deploy.projectId>
           <deploy.version>1</deploy.version>
         </configuration>
       </plugin>

--- a/portfolio/src/main/java/com/google/sps/servlets/NicknameServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/NicknameServlet.java
@@ -53,9 +53,21 @@ public class NicknameServlet extends HttpServlet {
     Query query = new Query("User")
         .setFilter(new Query.FilterPredicate("id", Query.FilterOperator.EQUAL, id));
 
+    // Search for the user(s) with the matching ID
     PreparedQuery results = datastore.prepare(query);
-    Entity entity = results.asSingleEntity();
-    if (entity != null) {
+    try {
+        // There should be either zero or one results, so try to treat it as one user
+        Entity entity = results.asSingleEntity();
+        if (entity != null) { // Redirect if this user already has a username registered
+            // TODO: Redirect to explanatory error page
+            response.sendRedirect("/index.html");
+            return;
+        }
+    }
+    catch (PreparedQuery.TooManyResultsException e) {
+        // There are multiple users with this ID; end the registration
+        // This is practically impossible but theoretically dangerous 
+        // TODO: Redirect to explanatory error page
         response.sendRedirect("/index.html");
         return;
     }

--- a/portfolio/src/main/java/com/google/sps/servlets/UserServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/UserServlet.java
@@ -1,0 +1,89 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.sps.servlets;
+
+import java.io.IOException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.ArrayList;
+
+import com.google.gson.Gson;
+import com.google.gson.annotations.SerializedName;
+
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.FetchOptions;
+import com.google.appengine.api.datastore.PreparedQuery;
+import com.google.appengine.api.datastore.Query;
+import com.google.appengine.api.datastore.Query.SortDirection;
+
+import com.google.appengine.api.users.UserService;
+import com.google.appengine.api.users.UserServiceFactory;
+import com.google.appengine.api.users.User;
+
+/** Servlet that handles user authentication. */
+@WebServlet("/user")
+public class UserServlet extends HttpServlet {
+
+  private class LoginStatus {
+    private boolean logged_in;
+    private String url;
+    private String nickname;
+
+    public LoginStatus(boolean logged_in, String url, String nickname) {
+      this.logged_in = logged_in;
+      this.url = url;
+      this.nickname = nickname;
+    }
+  }
+
+  String makeJSONStatus(boolean logged_in, String url, String nickname) {
+    Gson gson = new Gson();
+    String json = gson.toJson(new LoginStatus(logged_in, url, nickname));
+    return json;
+  }
+
+  @Override
+  public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    UserService userService = UserServiceFactory.getUserService();
+
+    boolean logged_in = userService.isUserLoggedIn();
+    String url = (logged_in)
+        ? userService.createLogoutURL("/")
+        : userService.createLoginURL("/");
+
+    User user = userService.getCurrentUser();
+    String id = (user != null) ? user.getUserId() : "";
+    String nickname = getUserNickname(id);
+
+    response.setContentType("text/json;");
+    response.getWriter().println(makeJSONStatus(logged_in, url, nickname));
+  }
+
+  private String getUserNickname(String id) {
+    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+    Query query = new Query("User")
+        .setFilter(new Query.FilterPredicate("id", Query.FilterOperator.EQUAL, id));
+
+    PreparedQuery results = datastore.prepare(query);
+    Entity entity = results.asSingleEntity();
+    return (entity == null)
+        ? ""
+        : (String) entity.getProperty("nickname");
+  }
+}

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -33,6 +33,10 @@
                 <li><a href="#life">Life</a></li>
                 <li><a href="#skills">Skills</a></li>
             </ul>
+            <div id="user-area">
+                <p id="nickname"></p>
+                <a id="login-button" class="user-button">Login</a>
+            </div>
         </div>
         <div id="content">
             <section id="about">
@@ -153,7 +157,7 @@
                     <div id="create-comment" class="card">
                         <form action="/data" method="POST">
                             <input type="text" id="new-comment" name="new-comment" placeholder="Type your comment here">
-                            <input type="submit" id="submit-comment">
+                            <input type="submit" value="submit" id="submit-comment">
                         </form>
                     </div>
                 </div>

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -18,10 +18,29 @@ function getComments() {
 }
 
 function deleteComments() {
-  fetch('/delete-data', {method: 'POST'}).then((_) => { getComments(); });
+  fetch('/delete-data', {method: 'POST'}).then(getComments);
+}
+
+function nicknamePrompt() {
+    // {Popup prompt with form that posts to server}
+    // Server should try to register nickname, and succeed iff uuid doesn't already have one
 }
 
 $(document).ready(function() {
+    fetch('/user').then(response => response.json())
+    .then((json) => {
+        let login_button = document.getElementById("login-button");
+        let nickname = document.getElementById("nickname");
+
+        login_button.href = json.url;
+        login_button.innerText = (json.logged_in)
+            ? "Logout"
+            : "Login";
+        nickname.innerHTML = (json.nickname == "")
+            ? "<a class=\"user-button\" onclick=\"nicknamePrompt()\">Set a nickname</a>"
+            : json.nickname;
+    });
+
     $('#submit-comment').prop('disabled',true);
     $('#new-comment').keyup(function() {
         $('#submit-comment').prop('disabled', (this.value == "")); 

--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -130,36 +130,6 @@ section hr {
     border-color: #DB4437;
 }
 
-/* #life>div {
-    display: table;
-    vertical-align: middle;
-    width: 916px;
-    height: 200px;
-    position: relative;
-    padding: 2px 4px 0 8px;
-}
-
-#life>div>div {
-    display: table-cell;
-    height: 250px;
-    width: 640px;
-}
-
-#life p {
-    position: absolute;
-    width: 640px;
-    top: 50%;
-    transform: translate(0, -50%);
-}
-
-.life-left {
-    float: left;
-}
-
-.life-right {
-    float: right;
-} */
-
 #projects img, #life img {
     display: inline-block;
     width: 300px;
@@ -275,4 +245,74 @@ section hr {
     font-size: 1.1em;
     padding-left: 12px;
     cursor: pointer;
+}
+
+#user-area {
+    position: fixed;
+    top: 18px;
+    right: 40px;
+}
+
+#user-area * {
+    display: inline-block;
+    float: left;
+    margin-left: 8px;
+}
+
+#login-button {
+    position: fixed;
+    top: 18px;
+    right: 40px;
+}
+
+#user-area * {
+    display: inline-block;
+    float: left;
+    margin-left: 8px;
+}
+
+
+#login-button {
+    position: fixed;
+    top: 18px;
+    right: 40px;
+}
+
+#user-area * {
+    display: inline-block;
+    float: left;
+    margin-left: 8px;
+}
+
+#login-button {
+    position: fixed;
+    top: 18px;
+    right: 40px;
+}
+
+.user-button {
+    background: white;
+    padding: 5px;
+    border-radius: 5px;
+    text-decoration: none;
+    color: #4285F4;
+    font-weight: bold;
+    margin-top: 10px
+}
+
+#nickname {
+    color: #fff;
+    font-weight: bold;
+}
+
+#nickname a {
+    float: none;
+    cursor: pointer;
+    display: inline;
+}
+
+.profile-thumb {
+    width: 45px;
+    height: 45px;
+    clip-path: circle(22px at center);
 }


### PR DESCRIPTION
Implemented backend servlets to handle user logins and nicknames. Using the AppEngine UserService API, UserServlet provides an API to create login and logout URLs, and to get information about a logged-in user. It currently has a simple, one-button frontend displayed in the top-right of the landing page. The button's text and href present the option to log in or out, depending on the URL and login state reported by UserServlet. Pressing the button will redirect the user to the appropriate login/logout page (depending on the unknown backend provider), and then redirect them back to the home page. The UserServlet will also return the user's nickname if it is present in the database. This implementation is robust to nickname changes and empty nicknames, as it is pulled each time UserServlet is GET-requested.

NicknameServlet provides a POST backend for registering a nickname for a user. It indexes users by UserId (as provided by UserService), and blocks requests attempting to override an existing username. No frontend is provided in this version, but it will work similarly to logging in. Nicknames will be used to identify users in comments, and will therefore be required to comment in future releases.

pom.xml: Change projectId.
DeleteServlet: Temporarily disable backend mass-deletion to prevent user-facing deletion.