### PR TITLE
Allow machine translation of comments with caching

### DIFF
--- a/portfolio/pom.xml
+++ b/portfolio/pom.xml
@@ -35,6 +35,12 @@
       <artifactId>appengine-api-1.0-sdk</artifactId>
       <version>1.9.59</version>
     </dependency>
+
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-translate</artifactId>
+      <version>1.70.0</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -110,7 +110,8 @@ public class DataServlet extends HttpServlet {
             (String) entity.getProperty("nickname")));
     }
     String json = commentsToJSON(comments);
-    response.setContentType("text/json;");
+    response.setContentType("text/json; charset=UTF-8");
+    response.setCharacterEncoding("UTF-8");
     response.getWriter().println(json);
   }
 

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -90,7 +90,6 @@ public class DataServlet extends HttpServlet {
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     Query query = new Query("User")
         .setFilter(new Query.FilterPredicate("id", Query.FilterOperator.EQUAL, id));
-    PreparedQuery results = datastore.prepare(query);
     Entity entity;
 
     // Search for the user(s) with the matching ID

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -143,7 +143,7 @@
             </section>
             <section id="comments">
                 <h1>Comments</h1>
-                <div id="num-comments-container">
+                <div class="comments-selector-container">
                     <label for="num-comments">Comments shown:</label>
                     <select name="num-comments" id="num-comments" onchange="getComments()">
                         <option value="5">5</option>
@@ -151,6 +151,16 @@
                         <option value="20">20</option>
                         <option value="50">50</option>
                         <option value="100">100</option>
+                    </select>
+                </div>
+                <div class="comments-selector-container" id="language-container">
+                    <label for="language">Language:</label>
+                    <select name="language" id="language" onchange="getComments()">
+                        <option value="en">English</option>
+                        <option value="es">Spanish</option>
+                        <option value="zh">Chinese</option>
+                        <option value="hi">Hindi</option>
+                        <option value="ar">Arabic</option>
                     </select>
                 </div>
                 <div id="comments-area" class="card">

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Henry Sloan</title>
     <link rel="stylesheet" href="style.css">
     <script src="https://kit.fontawesome.com/a076d05399.js"></script>

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -25,7 +25,8 @@ function getComments() {
   let comments = document.getElementById('comments-container');
   comments.innerHTML = "";
   let num_comments = parseInt(document.getElementById('num-comments').value);
-  fetch('/data?num-comments=' + num_comments).then(response => response.json())
+  let language = document.getElementById('language').value;
+  fetch('/data?num-comments=' + num_comments + "&language=" + language).then(response => response.json())
   .then((json) => {
     json.forEach(comment => {
       comments.innerHTML += formatComment(comment.content, comment.nickname, comment.timestamp);

--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -247,11 +247,15 @@ section hr {
     box-sizing: border-box;
 }
 
-#num-comments-container {
+.comments-selector-container {
     float: right;
     display: inline-block;
     padding-top: 8px;
     font-size: 1.1em;
+}
+
+#language-container {
+    padding-right: 20px;
 }
 
 #delete-button {


### PR DESCRIPTION
index.html adds a new selector above the comments section, allowing the user to select between several widely spoken languages.

A new translation helper function has been added to DataServlet. When comments are being retrieved, they are sent to the helper function to be translated into the selected target language. If the language is English (the assumed language of comments as served on the default website), no translation is performed. If the comment is being translated to a new language (one which the comment has never been displayed in before), then a cloud translation will occur, and the result will be cached. If a given comment has already been translated in to a particular language, the result will simply be pulled from the datastore and displayed. This solution provides rapid recall of new comments on the default page, low-overhead posting that will scale to more languages, and minimal extra computation time for new translations.