### PR TITLE
Create new single-column layout for mobile screens

### DIFF
--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -139,6 +139,7 @@ public class DataServlet extends HttpServlet {
     Entity entity;
 
     // Search for the user(s) with the matching ID
+    PreparedQuery results = datastore.prepare(query);
     try {
         // There should be either zero or one results, so try to treat it as one user
         entity = results.asSingleEntity();

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -147,6 +147,7 @@
             </section>
             <section id="comments">
                 <h1>Comments</h1>
+                <a id="comments-logout" class="user-button">Logout</a>
                 <div class="comments-selector-container">
                     <label for="num-comments">Comments shown:</label>
                     <select name="num-comments" id="num-comments" onchange="getComments()">

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -170,7 +170,7 @@
                 <div id="comments-area" class="card">
                     <span id="comments-container"></span>
                     <div id="create-comment" class="card">
-                        <form action="/data" method="POST">
+                        <form action="/data" method="POST" autocomplete="off">
                             <input type="text" id="new-comment" name="new-comment" placeholder="Type your comment here">
                             <input type="submit" value="Submit" id="submit-comment">
                         </form>

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -77,11 +77,18 @@ $(document).ready(function() {
     .then((json) => {
         let login_button = document.getElementById("login-button");
         let nickname = document.getElementById("nickname");
+        let comments_logout = document.getElementById("comments-logout");
 
         login_button.href = json.url;
         login_button.innerText = (json.logged_in)
             ? "Logout"
             : "Login";
+        if (json.logged_in) {
+            comments_logout.href = json.url;
+        }
+        else {
+            comments_logout.style.display = "none";
+        }
         nickname.innerHTML = (json.logged_in && json.nickname == "")
             ? "<a class=\"user-button\" onclick=\"nicknamePrompt()\">Set a nickname</a>"
             : json.nickname;

--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -384,7 +384,32 @@ section hr {
         max-width: 250px;
         position: absolute;
         bottom: 50px;
+        left: auto;
         right: 0;
+    }
+
+    #sidenav-footer {
+        position: absolute;
+        bottom: 10px;
+        right: 15px;
+    }
+
+    #sidenav-footer a {
+        margin: 0;
+    }
+
+    #sidenav-footer .fab, #sidenav-footer .fas {
+        font-size: 2.1em;
+        margin-right: 30px;
+        float: left;
+    }
+
+    #sidenav-footer p {
+        display: none;
+    }
+
+    #sidenav-footer div {
+        display: inline;
     }
 
     .profile-img {

--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -364,3 +364,23 @@ section hr {
 .cards-flex .card h2 {
     margin: 3% 0;
 }
+
+@media only screen and (max-width: 1000px) {
+    #sidenav {
+        height: 200px;
+        width: 100%;
+        position: relative;
+    }
+
+    #header {
+        display: none;
+    }
+
+    #content-container {
+        margin: 0;
+    }
+
+    #content {
+        margin-top: 16px;
+    }
+}

--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -50,7 +50,7 @@ body {
 .profile-img {
     width: 200px;
     height: 200px;
-    clip-path: circle(100px at center);
+    clip-path: circle(50% at center);
 }
 
 #sidenav h1, #sidenav h2 {
@@ -367,9 +367,30 @@ section hr {
 
 @media only screen and (max-width: 1000px) {
     #sidenav {
+        padding: 12px;
         height: 200px;
         width: 100%;
         position: relative;
+        box-sizing: border-box;
+    }
+
+    #sidenav h1, #sidenav h2 {
+        display: inline-block;
+        float: right;
+    }
+
+    #sidenav h2 {
+        width: 50%;
+        max-width: 250px;
+        position: absolute;
+        bottom: 50px;
+        right: 0;
+    }
+
+    .profile-img {
+        position: absolute;
+        width: 175px;
+        height: 175px;
     }
 
     #header {
@@ -382,5 +403,31 @@ section hr {
 
     #content {
         margin-top: 16px;
+    }
+
+    .cards-flex {
+        margin-right: 0;
+    }
+
+    .cards-flex .card {
+        display: inline-block;
+        width: auto;
+        min-width: 0;
+    }
+
+    .project-info {
+        min-height: 0;
+        margin-bottom: 8px;
+    }
+
+    #life .project-info {
+        width: auto;
+        height: auto;
+    }
+
+    #life p {
+        width: auto;
+        position: relative;
+        transform: none;
     }
 }

--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -185,9 +185,8 @@ section hr {
 }
 
 .skill-list h2 {
-    text-align: center;
     margin: 0;
-    margin-left: -16px;
+    margin-left: 22px;
 }
 
 .skill-list ul {
@@ -376,22 +375,22 @@ section hr {
 
     #sidenav h1, #sidenav h2 {
         display: inline-block;
-        float: right;
-    }
-
-    #sidenav h2 {
         width: 50%;
         max-width: 250px;
         position: absolute;
-        bottom: 50px;
         left: auto;
-        right: 0;
+        right: 4px;
+    }
+
+    #sidenav h2 {
+        bottom: 50px;
     }
 
     #sidenav-footer {
         position: absolute;
         bottom: 10px;
         right: 15px;
+        left: auto;
     }
 
     #sidenav-footer a {
@@ -454,5 +453,30 @@ section hr {
         width: auto;
         position: relative;
         transform: none;
+    }
+
+    #comments {
+        width: auto;
+    }
+
+    #comments-area {
+        width: 96%;
+    }
+
+    .comment {
+        width: auto;
+        display: block;
+    }
+
+    #create-comment {
+        display: block;
+        width: auto;
+        padding: 14px 6px 14px 14px;
+    }
+
+    .comments-selector-container {
+        float: none;
+        display: block;
+        padding: 0 0 8px 16px;
     }
 }

--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -364,6 +364,15 @@ section hr {
     margin: 3% 0;
 }
 
+#comments-logout {
+    display: none;
+    position: absolute;
+    right: 10px;
+    top: 0px;
+    background: #4285F4;
+    color: white;
+}
+
 @media only screen and (max-width: 1000px) {
     #sidenav {
         padding: 12px;
@@ -455,12 +464,20 @@ section hr {
         transform: none;
     }
 
+    section {
+        position: relative;
+    }
+
     #comments {
         width: auto;
     }
 
     #comments-area {
         width: 96%;
+    }
+
+    #comments-logout {
+        display: block;
     }
 
     .comment {
@@ -470,7 +487,7 @@ section hr {
 
     #create-comment {
         display: block;
-        width: auto;
+        width: auto !important;
         padding: 14px 6px 14px 14px;
     }
 


### PR DESCRIPTION
Using CSS media queries, the website now displays differently on sufficiently small displays. Most importantly, the sidebar becomes a header, and the header navbar is removed completely. The CSS changes largely allow all information to display cleanly in a single column with adaptive width. The comments section has been slightly reworked on small screens to allow for logging in and out, as well as setting nicknames without using a navbar.

<img width="200" alt="portfolio_view" src="https://user-images.githubusercontent.com/30727195/84433879-00fede00-abfd-11ea-954d-ca4576f3f298.jpg">


